### PR TITLE
Unificação dos pacotes Nuget

### DIFF
--- a/Nuget/.gitignore
+++ b/Nuget/.gitignore
@@ -1,0 +1,5 @@
+**
+!lib/**
+!Fcm.net.nuspec
+!BuildNugetPackage.bat
+!.gitignore

--- a/Nuget/BuildNugetPackage.bat
+++ b/Nuget/BuildNugetPackage.bat
@@ -1,0 +1,13 @@
+@echo off
+
+REM Cria os dirs
+if not exist lib\net452 md lib\net452
+if not exist lib\netstandard1 md lib\netstandard1
+if not exist lib\portable46-net451+win81+wpa81 md lib\portable46-net451+win81+wpa81
+
+REM Copia cada dll de sua pasta de origem para a pasta lib do nuget
+copy /y ..\fcm.net\bin\release\fcm.net.dll lib\net452
+copy /y ..\fcm.net.standard\bin\release\netstandard1.6\FCM.Net.Standard.dll lib\netstandard1.6
+copy /y ..\fcm.net.pcl\bin\release\FCM.Net.pcl.dll "lib\portable46-net451+win81+wpa81"
+
+nuget pack FCM.net.nuspec

--- a/Nuget/FCM.net.nuspec
+++ b/Nuget/FCM.net.nuspec
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>FCM.Net</id>
+	<!-- TODO: Trocar para variavel com $$ -->
+    <version>1.0.1</version>
+    <title>FCM.Net</title>
+    <authors>Angelo Belchior</authors>
+    <owners>Angelo Belchior</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Biblioteca para facilitar envio de Push Notification usando o Firebase Cloud Messaging do Google</description>
+    <copyright>Copyright ©  2017</copyright>
+	<!-- Dependencias -->
+	<group targetFramework="net452">
+		<dependencies>
+		  <dependency id="Microsoft.Bcl.Build" version="1.0.21" />
+		  <dependency id="Microsoft.Net.Http" version="2.2.29" />
+		  <dependency id="Newtonsoft.Json" version="9.0.1" />
+		</dependencies>
+	</group>
+	<group targetFramework="NETStandard1.6">
+		<dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
+		<dependency id="Newtonsoft.Json" version="9.0.1" exclude="Build,Analyzers" />
+    </group>
+	<group targetFramework="portable-net4+sl50+win8+wpa81">
+		<dependencies>
+			<dependency id="Microsoft.Bcl.Build" version="1.0.21" />
+			<dependency id="Microsoft.Net.Http" version="2.2.29" />
+			<dependency id="Newtonsoft.Json" version="9.0.1" />
+		</dependencies>
+	</group>
+	
+	<!-- Libs -->
+	<files>
+		<file src="lib\**" target="lib" />
+	</files>
+    <iconUrl>https://raw.githubusercontent.com/angelobelchior/FCM.Net/master/FCM.Net.png</iconUrl>
+    <projectUrl>https://github.com/angelobelchior/FCM.Net</projectUrl>
+    <summary>Essa biblioteca foi escrita seguindo a documentação do próprio Google (https://firebase.google.com/docs/cloud-messaging/) com o intuito de facilitar o envio de mensagens a partir de um server app / desktop app (Console Application, Asp.Net, Windows Forms, WPF, etc).</summary>
+    <tags>.net google android fcm Firebase Cloud Messaging </tags>
+  </metadata>
+</package>

--- a/Nuget/FCM.net.nuspec
+++ b/Nuget/FCM.net.nuspec
@@ -11,32 +11,29 @@
     <description>Biblioteca para facilitar envio de Push Notification usando o Firebase Cloud Messaging do Google</description>
     <copyright>Copyright ©  2017</copyright>
 	<!-- Dependencias -->
-	<group targetFramework="net452">
-		<dependencies>
+	<dependencies>
+		<group targetFramework="net452">
 		  <dependency id="Microsoft.Bcl.Build" version="1.0.21" />
 		  <dependency id="Microsoft.Net.Http" version="2.2.29" />
 		  <dependency id="Newtonsoft.Json" version="9.0.1" />
-		</dependencies>
-	</group>
-	<group targetFramework="NETStandard1.6">
-		<dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
-		<dependency id="Newtonsoft.Json" version="9.0.1" exclude="Build,Analyzers" />
-    </group>
-	<group targetFramework="portable-net4+sl50+win8+wpa81">
-		<dependencies>
+		</group>
+		<group targetFramework="NETStandard1.6">
+			<dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
+			<dependency id="Newtonsoft.Json" version="9.0.1" exclude="Build,Analyzers" />
+		</group>
+		<group targetFramework="portable-net4+sl50+win8+wpa81">
 			<dependency id="Microsoft.Bcl.Build" version="1.0.21" />
 			<dependency id="Microsoft.Net.Http" version="2.2.29" />
 			<dependency id="Newtonsoft.Json" version="9.0.1" />
-		</dependencies>
-	</group>
+		</group>
+	</dependencies>
 	
-	<!-- Libs -->
-	<files>
-		<file src="lib\**" target="lib" />
-	</files>
     <iconUrl>https://raw.githubusercontent.com/angelobelchior/FCM.Net/master/FCM.Net.png</iconUrl>
     <projectUrl>https://github.com/angelobelchior/FCM.Net</projectUrl>
     <summary>Essa biblioteca foi escrita seguindo a documentação do próprio Google (https://firebase.google.com/docs/cloud-messaging/) com o intuito de facilitar o envio de mensagens a partir de um server app / desktop app (Console Application, Asp.Net, Windows Forms, WPF, etc).</summary>
     <tags>.net google android fcm Firebase Cloud Messaging </tags>
   </metadata>
+	<files>
+		<file src="lib\**" target="lib" />
+	</files>
 </package>


### PR DESCRIPTION
Fala gordo careca!

Achei da hora a lib e começamos a usar aqui. Fiz uma pequena pioria no esquema de geração dos packs do nuget:
- criei um diretório chamado Nuget com as porra toda;
- criei um nuspec que tenta atender todos os targets da lib;
- criei uma bat em homenagem ao Coutinho para gerar o pack do nuget com base no nuspec;

Acho que com um pacote só fica mais fácil, manter tudo organizado e os números de uso consolidados.

Veja aí o que acha! Abraço