### PR TITLE
Change JsonPropeperty name from time_to_live to ttl according to http…

### DIFF
--- a/Code/Message.cs
+++ b/Code/Message.cs
@@ -58,7 +58,7 @@ namespace FCM.Net
         /// <summary>
         /// This parameter specifies how long (in seconds) the message should be kept in FCM storage if the device is offline. The maximum time to live supported is 4 weeks, and the default value is 4 weeks. 
         /// </summary>
-        [JsonProperty("time_to_live")]
+        [JsonProperty("ttl")]
         public int? TimeToLive { get; set; }
 
         /// <summary>


### PR DESCRIPTION
I changed JsonProperty name from time_to_live to ttl according to https://firebase.google.com/docs/cloud-messaging/android/topic-messaging

This is not the best solution but at the moment it solves the problem of transferring time to live to FCM